### PR TITLE
Fix capitalisation of the highcharts dependency and allow for common JS style imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,6 @@
     },
     "homepage": "https://github.com/highcharts/rounded-corners#readme",
     "dependencies": {
-        "Highcharts": ">=3.0.0"
+        "highcharts": ">=3.0.0"
     }
 }

--- a/rounded-corners.js
+++ b/rounded-corners.js
@@ -5,7 +5,15 @@
  * Version: 1.0.5
  * License: MIT License
  */
-(function (H) {
+(function (factory) {
+    "use strict";
+
+    if (typeof module === "object" && module.exports) {
+        module.exports = factory;
+    } else {
+        factory(Highcharts);
+    }
+}(function (H) {
     var rel = H.relativeLength;
 
     H.wrap(H.seriesTypes.column.prototype, 'translate', function (proceed) {
@@ -77,5 +85,4 @@
                 
         });
     });
-}(Highcharts));
-
+}));


### PR DESCRIPTION
This PR fixes issue https://github.com/highcharts/rounded-corners/issues/21

The `highcharts` dependency is incorrectly capitalised which will fail an install with yarn