### PR TITLE
Replace deprecated Highcharts.each function

### DIFF
--- a/rounded-corners.js
+++ b/rounded-corners.js
@@ -23,7 +23,7 @@
 
         proceed.call(this);
 
-        H.each(this.points, function (point) {
+        this.points.forEach(function (point) {
             var shapeArgs = point.shapeArgs,
                 w = shapeArgs.width,
                 h = shapeArgs.height,


### PR DESCRIPTION
Highcharts.each is deprecated, and you now get a console warning to that effect:
![image](https://user-images.githubusercontent.com/4006396/85760391-ca869000-b6df-11ea-9f38-915e901d539f.png)
Switched to array.forEach as recommended